### PR TITLE
Pausing before microservices are deployed.

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -132,6 +132,10 @@ cd
 
 ## Deploy microservices
 
+### Sleeping 10s so that Ingress object could be created.
+### See https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/2013
+sleep 10
+
 ### Orders microservice
 echo 'Deploying Orders microservice'
 git clone ${GIT_URL}/amazon-eks-saga-orchestration-orders


### PR DESCRIPTION
*Description of changes:*

- Added `sleep` before microservices are deployed. See https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/2013

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
